### PR TITLE
Automatic build.gradle setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,6 @@ This plugin uses a hook (after prepare) that copies the configuration files to t
 
 Hooks does not work with PhoneGap Build. This means you will have to manually make sure the configuration files are included. One way to do that is to make a private fork of this plugin and replace the placeholder config files (see src/ios and src/android) with your actual ones.
 
-### Notes about Android Build
-
-You will have to manually add the following to platforms/android/build.gradle (around line 34:
-```
-buildscript {
-	...
-	dependencies { 
-		...
-		classpath 'com.google.gms:google-services:3.0.0'
-	}
-}
-````
-
 ## Methods
 
 ### ref

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,7 +25,6 @@
 		<source-file src="src/android/FirebaseDatabasePlugin.java" target-dir="src/org/apache/cordova/firebase" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
-		<framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
 		<framework src="com.google.android.gms:play-services-analytics:9.0.0" />
 		<framework src="com.google.code.gson:gson:2.+" />
 		<framework src="com.google.firebase:firebase-core:9.4.0" />

--- a/src/android/FirebaseDatabasePlugin.java
+++ b/src/android/FirebaseDatabasePlugin.java
@@ -24,6 +24,7 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigInfo;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
+import com.google.firebase.FirebaseApp;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
 
@@ -50,9 +51,11 @@ public class FirebaseDatabasePlugin extends CordovaPlugin {
         final Context context = this.cordova.getActivity().getApplicationContext();
         this.cordova.getThreadPool().execute(new Runnable() {
             public void run() {
-                Log.d(TAG, "Starting Firebase plugin");
-                mDatabase = FirebaseDatabase.getInstance().getReference();
-                mAuth = FirebaseAuth.getInstance();
+                if (!FirebaseApp.getApps(context).isEmpty()) {
+                    Log.d(TAG, "Starting Firebase plugin");
+                    mDatabase = FirebaseDatabase.getInstance().getReference();
+                    mAuth = FirebaseAuth.getInstance();
+                }
             }
         });
     }

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,12 +1,1 @@
-cdvPluginPostBuildExtras.add({
-  println 'handscan-build-extras'
-  buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.google.gms:google-services:3.0.0'
-    }
-  }
-  apply plugin: 'com.google.gms.google-services'
-})
+apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
Previously had to manually add the google services classpath to the
generated build.gradle. Now it is added automatically with
build-extras.gradle. Added a fix for using Firebase Crash Reporting by
checking Firebase is configured before getting the reference. See
http://stackoverflow.com/questions/37346363/java-lang-illegalstateexception-firebaseapp-with-name-default